### PR TITLE
style: change docker build ARG from _VERSION to _TAG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG ALPINE_VERSION=3.8
-FROM alpine:${ALPINE_VERSION}
+ARG ALPINE_TAG=3.8
+FROM alpine:${ALPINE_TAG}
 
 ## Build ARGs
 # Autobuild


### PR DESCRIPTION
`ARG` name now better reflects docker terminology; images are tagged,
and technically that is what is being pulled (despite tags often following
versions)

Closes #4.